### PR TITLE
update node-versions for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # the Node.js versions to build on
-        node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
+        node-version: [12.x, 13.x, 14.x, 15.x, 16.x, 17.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Removes 10.x and adds 16.x and 17.x node versions for CI testing 