### PR TITLE
add a slash to registry url for node setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
-          registry-url: "https://registry.npmjs.org"
+          registry-url: "https://registry.npmjs.org/"
 
       - run: npm install
 


### PR DESCRIPTION
Per the [GitHub documentation](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages) the `registry_url` needs to end in a `/`.