### PR TITLE
chore: enable skipLibCheck to unblock homebridge v2

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
 		"strictPropertyInitialization": false,
 		"strictFunctionTypes": false,
 		"esModuleInterop": true,
+		"skipLibCheck": true,
 		"outDir": "./dist",
 		"rootDir": "./src"
 	},


### PR DESCRIPTION
## Summary

Adds `"skipLibCheck": true` to tsconfig. This is the one-line unblock for #448 (homebridge v2): homebridge 2.x ships `@matter/*` type declarations that can't resolve under this project's default (node10) module resolution, causing ~1300 `tsc` errors from `node_modules` even though the plugin's own `src/` compiles clean against homebridge 2 typings.

`skipLibCheck` stops tsc from type-checking dependency `.d.ts` files. The plugin's own code is still fully type-checked.

## Verification

- On current deps (homebridge 1.11.x): build, tests (15/15), and lint all pass — no behavior change.
- With `homebridge@2.2.1` installed locally: `npm run build` goes from ~1300 errors to clean, and all 15 tests pass.

After this merges, #448 needs a Renovate rebase to pick it up and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)